### PR TITLE
Trivial change to support Lua 5.1/LuaJIT.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION=0.29.0
-REVISION=1
+REVISION=2
 ROCKSPEC=lcmark-$(VERSION)-$(REVISION).rockspec
 TESTS=tests
 CMARK_DIR=../cmark

--- a/rockspec.in
+++ b/rockspec.in
@@ -23,7 +23,7 @@ description = {
     maintainer = "John MacFarlane <jgm@berkeley.edu>",
 }
 dependencies = {
-   "lua >= 5.2",
+   "lua >= 5.1",
    "cmark >= 0.29.0",
    "yaml >= 1.1",
    "lpeg >= 0.12",

--- a/test.t
+++ b/test.t
@@ -95,7 +95,7 @@ is(msg, "cannot open nonexistent.lua: No such file or directory", "message on no
 
 local badfilter, msg = lcmark.load_filter("tests/bad_filter.lua")
 nok(badfilter, "load_filter fails on bad filter")
-is(msg, "tests/bad_filter.lua:2: <name> expected near '('", "error message on bad filter")
+like(msg, "tests/bad_filter%.lua:2: '?<name>'? expected near '%('", "error message on bad filter")
 
 local badfilter, msg = lcmark.load_filter("tests/bad_filter2.lua")
 nok(badfilter, "load_filter fails when script doesn't return a function")
@@ -104,7 +104,7 @@ is(msg, "Filter tests/bad_filter2.lua returns a table, not a function", "error m
 local badfilter, msg = lcmark.load_filter("tests/bad_filter3.lua")
 local doc, meta, msg = lcmark.convert("test", "html", {filters = {badfilter}})
 nok(doc, "trap runtime error raised by filter")
-is(msg, "Error running filter:\ntests/bad_filter3.lua:2: attempt to perform arithmetic on a userdata value (local 'doc')", "error message on runtime error from filter")
+like(msg, "Error running filter:\ntests/bad_filter3%.lua:2: attempt to perform arithmetic on .*local 'doc'", "error message on runtime error from filter")
 
 local count_links = lcmark.load_filter("filters/count_links.lua")
 ok(count_links, "loaded filter count_links.lua")


### PR DESCRIPTION
## Changes
- Fixes issue #3.
- Avoids polluting the global environment when creating the environment for the loaded filters.
- Tests modified to account for slight differences in error messages across Lua versions.

## Notes
This passes all your tests on LuaJIT 2.1, Lua 5.1, 5.2, and 5.3. That said, I don't have actual data to test it on at this point, so there may be some issues... but I didn't notice any 5.2+-specific features used aside from `_ENV`, so I think this should be entirely 5.1 compatible.