### PR TITLE
Make YAML metadata parsing function configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION=0.29.0
-REVISION=2
+REVISION=3
 ROCKSPEC=lcmark-$(VERSION)-$(REVISION).rockspec
 TESTS=tests
 CMARK_DIR=../cmark

--- a/README.md
+++ b/README.md
@@ -151,11 +151,11 @@ local body, metadata = lcmark.convert("Hello *world*",
                          "latex", {smart = true, columns = 40})
 ```
 
-The module exports
+The module exports:
 
-`lcmark.version`: a string with the version number.
+-   `lcmark.version`: a string with the version number.
 
-`lcmark.writers`: a table with strings as keys (`html`, `latex`,
+-   `lcmark.writers`: a table with strings as keys (`html`, `latex`,
     `man`, `xml`, `commonmark`) and renderers as values.  A
     renderer is a function that takes three arguments (a
     cmark node, cmark options (a number), and a column width
@@ -187,6 +187,14 @@ The module exports
     rendered document body and `meta` is a metatable table whose
     leaf values are rendered subdocuments), or `nil, nil, msg` on
     failure.
+
+-   `lcmark.set_yaml_loader(yaml_loader_fn)`:
+    Configure the function used to parse YAML metadata. `yaml_loader_fn` must
+    be a function that takes a valid YAML string and returns a Lua table
+    representation of the YAML structure.
+
+    Defaults to `yaml.load` from
+    [yaml](https://luarocks.org/modules/gaspard/yaml).
 
 For developers
 --------------

--- a/lcmark.lua
+++ b/lcmark.lua
@@ -1,11 +1,15 @@
 local cmark = require("cmark")
-local yaml = require("yaml")
 local lpeg = require("lpeg")
 
 local S, C, P, R, V, Ct =
   lpeg.S, lpeg.C, lpeg.P, lpeg.R, lpeg.V, lpeg.Ct
 local nl = P"\r\n" + P"\r" + P"\n"
 local sp = S" \t"^0
+
+local yaml_loader = function(str)
+  local yaml = require("yaml")
+  return yaml.load(str)
+end
 
 local lcmark = {}
 
@@ -144,7 +148,7 @@ local parse_document_with_metadata = function(inp, options)
   if meta_end then
     if meta_end then
       local ok, yaml_meta = pcall(function ()
-                              return yaml.load(string.sub(inp, 1, meta_end))
+                              return yaml_loader(string.sub(inp, 1, meta_end))
                             end)
       if not ok then
         return nil, yaml_meta -- the error message
@@ -393,6 +397,10 @@ function lcmark.convert(inp, to, options)
   cmark.node_free(doc)
   walk_table(meta, cmark.node_free, true)
   return body, data
+end
+
+function lcmark.set_yaml_loader(yaml_loader_fn)
+  yaml_loader = yaml_loader_fn
 end
 
 return lcmark


### PR DESCRIPTION
lyaml is a drop-in replacement for lcmark's usage. Both modules are bindings to the same C library (LibYAML), but:
- lyaml is actually maintained.
- lyaml is a binding to the system LibYAML, instead of an ancient
  vendored copy.

(You should bump the rockspec revision if you do merge this, I guess?)