### PR TITLE
Evaluate empty tables as falsy

### DIFF
--- a/lcmark.lua
+++ b/lcmark.lua
@@ -212,6 +212,11 @@ local set_value = function(var, newval, ctx)
   return true
 end
 
+local is_truthy = function(val)
+  local is_empty_tbl = type(val) == "table" and #val == 0
+  return val and not is_empty_tbl
+end
+
 -- if s starts with newline, remove initial and final newline
 local trim = function(s)
   if s:match("^[\r\n]") then
@@ -224,7 +229,7 @@ end
 local conditional = function(var, ifpart, elsepart)
   return function(ctx)
     local result
-    if get_value(var, ctx) then
+    if is_truthy(get_value(var, ctx)) then
       result = lcmark.apply_template(ifpart, ctx)
     elseif elsepart then
       result = lcmark.apply_template(elsepart, ctx)
@@ -239,7 +244,7 @@ local forloop = function(var, inner, sep)
   return function(ctx)
     local val = get_value(var, ctx)
     local vs
-    if not val then
+    if not is_truthy(val) then
       return ""
     end
     if type(val) == 'table' then
@@ -293,7 +298,7 @@ local TemplateGrammar = Ct{"Main",
     function(var)
       return function(ctx)
         local val = get_value(var, ctx)
-        if val then
+        if is_truthy(val) then
           return tostring(val)
         else
           return ""

--- a/test.t
+++ b/test.t
@@ -27,6 +27,10 @@ subtest("template tests", function()
     "foo bim", "variable")
   is(render_template("foo $bim$", {bar = "bim"}),
     "foo ", "missing variable")
+  is(render_template("foo $bar$", {bar = false}),
+    "foo ", "variable with false")
+  is(render_template("foo $bar$", {bar = {}}),
+    "foo ", "variable with empty table")
   is(render_template("foo $bar.baz$", {bar = { baz = "bim" }}),
     "foo bim", "variable with field")
   is(render_template("foo $bar.baz.bar$", {bar = { baz = "bim" }}),
@@ -35,6 +39,8 @@ subtest("template tests", function()
     "hello", "simple if")
   is(render_template("$if(foo)$hello$endif$", {}),
     "", "simple if with missing variable")
+  is(render_template("$if(foo)$hello$endif$", {foo = {}}),
+    "", "simple if with empty table")
   is(render_template("$if(foo)$hello $foo$$endif$", {foo = true}),
     "hello true", "if with variable")
   is(render_template("$if(foo)$hello$else$goodbye$endif$", {foo = true}),


### PR DESCRIPTION
Partially fixes https://github.com/jgm/lcmark/issues/8 and adds tests for falsy values in templates.