### PR TITLE
Preserve non-string metadata types

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ The YAML metadata section (if present) must occur at the
 beginning of the document.  It begins with a line `---`
 and end with a line `...` or `---`.  Between these, a YAML
 key/value map is expected.  YAML escaping rules must be
-followed.  The values may be YAML arrays, maps, or strings;
-strings will be interpreted as CommonMark.
+followed.  String values will be interpreted as CommonMark.
 
 Example:
 
@@ -132,10 +131,10 @@ Filters
 Filters modify the parsed document prior to rendering.
 
 A filter is a function that takes three arguments ('doc',
-'meta', 'to'), where 'doc' is a cmark node, 'meta' is a nested
-lua table whose leaf nodes are cmark nodes, and 'to' is a string
-specifying the output format.  The function may destructively
-modify 'doc' and 'meta'.
+'meta', 'to'), where 'doc' is a cmark node, 'meta' is the YAML
+metadata as a nested Lua table with all strings replaced by
+cmark nodes, and 'to' is a string specifying the output format.
+The function may destructively modify 'doc' and 'meta'.
 
 Some sample filters are provided in
 [`filters/`](https://github.com/jgm/lcmark/tree/master/filters).
@@ -185,8 +184,8 @@ The module exports
 
     Returns `body`, `meta` on success (where `body` is the
     rendered document body and `meta` is a metatable table whose
-    leaf values are rendered subdocuments), or `nil, nil, msg` on
-    failure.
+    string leaf values are rendered subdocuments), or
+    `nil, nil, msg` on failure.
 
 For developers
 --------------

--- a/lcmark.lua
+++ b/lcmark.lua
@@ -130,7 +130,7 @@ local convert_metadata = function(table, options)
                       if type(s) == "string" then
                         return cmark.parse_string(s, options)
                       elseif type(s) == "userdata" then
-                        error("metadata must not contain userdata")
+                        return tostring(s)
                       else
                         return s
                       end

--- a/lcmark.lua
+++ b/lcmark.lua
@@ -127,7 +127,13 @@ end
 local convert_metadata = function(table, options)
   return walk_table(table,
                     function(s)
-                      return cmark.parse_string(tostring(s), options)
+                      if type(s) == "string" then
+                        return cmark.parse_string(s, options)
+                      elseif type(s) == "userdata" then
+                        error("metadata must not contain userdata")
+                      else
+                        return s
+                      end
                     end, false)
 end
 
@@ -391,12 +397,20 @@ function lcmark.convert(inp, to, options)
   local body = writer(doc, opts, columns)
   local data = walk_table(meta,
                           function(node)
-                            local res = render_metadata(node, writer, opts, columns)
-                            return res
+                            if type(node) == "userdata" then
+                              return render_metadata(node, writer, opts, columns)
+                            else
+                              return node
+                            end
                           end, false)
   -- free memory allocated by libcmark
   cmark.node_free(doc)
-  walk_table(meta, cmark.node_free, true)
+  walk_table(meta,
+             function(node)
+               if type(node) == "userdata" then
+                 cmark.node_free(node)
+               end
+             end, true)
   return body, data
 end
 


### PR DESCRIPTION
Current behaviour parses each leaf node of the metadata as a CommonMark string, which doesn't make sense for data types such as `null`s and booleans (and can lead to surprising behaviour).

This pull request limits CommonMark parsing to only string nodes to allow numbers, booleans, nulls, etc. in the metadata. cmark nodes are then differentiated from other nodes using a `type() == "userdata"` check (I am not sure whether there is a better way to check whether something is a cmark node).

~~Although this is a pretty breaking change, it passes all the tests~~.

~~Progresses https://github.com/jgm/lcmark/issues/8~~.

See comment below.  