### PR TITLE
Support custom YAML parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ To install:  `luarocks install lcmark`.
 
 (This installs both the library and the program.)
 
+Additionally, unless you want to use a different YAML library (see the
+`yaml_parser` option), you will need [yaml](https://github.com/lubyk/yaml):
+
+`luarocks install yaml`
+
 lcmark (program)
 ------------------
 
@@ -39,6 +44,12 @@ and end with a line `...` or `---`.  Between these, a YAML
 key/value map is expected.  YAML escaping rules must be
 followed.  The values may be YAML arrays, maps, or strings;
 strings will be interpreted as CommonMark.
+
+By default, lcmark attempts to use [yaml](https://github.com/lubyk/yaml).
+However, if the `yaml_parser` option (a function) is provided, lcmark will use
+that instead. Said function  should take a string as input and should return a
+table. In case of failure, it should throw an error; non-table returns will be
+discarded silently.
 
 Example:
 
@@ -182,6 +193,7 @@ The module exports
     - `filters` - an array of filters to run (see `load_filter` above)
     - `columns` - column width, or 0 to preserve wrapping in input
     - `yaml_metadata` - parse initial YAML metadata block
+    - `yaml_parser` - a function to parse YAML with (see [YAML Metadata](#yaml-metadata))
 
     Returns `body`, `meta` on success (where `body` is the
     rendered document body and `meta` is a metatable table whose

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ To install:  `luarocks install lcmark`.
 
 (This installs both the library and the program.)
 
-Additionally, unless you want to use a different YAML library (see the
-`yaml_parser` option), you will need [yaml](https://github.com/lubyk/yaml):
-
-`luarocks install yaml`
+Additionally, you'll also need a YAML parsing library. lcmark will automatically
+attempt to load and use one of [yaml](https://github.com/lubyk/yaml),
+[lua-yaml](https://github.com/exosite/lua-yaml) or
+[lyaml](https://github.com/gvvaughan/lyaml). Alternatively, a custom parser can
+be used (see the `yaml_parser` option below).
 
 lcmark (program)
 ------------------
@@ -45,11 +46,10 @@ key/value map is expected.  YAML escaping rules must be
 followed.  The values may be YAML arrays, maps, or strings;
 strings will be interpreted as CommonMark.
 
-By default, lcmark attempts to use [yaml](https://github.com/lubyk/yaml).
-However, if the `yaml_parser` option (a function) is provided, lcmark will use
-that instead. Said function  should take a string as input and should return a
-table. In case of failure, it should throw an error; non-table returns will be
-discarded silently.
+If the `yaml_parser` option (a function) is provided, lcmark will use it to
+parse YAML. The function should take a string as input and should return a
+table. In case of failure, it should either throw an error or return a `nil`,
+`err` tuple; other returns will be discarded silently.
 
 Example:
 
@@ -164,9 +164,17 @@ local body, metadata = lcmark.convert("Hello *world*",
 
 The module exports
 
-`lcmark.version`: a string with the version number.
+- `lcmark.version`: a string with the version number.
 
-`lcmark.writers`: a table with strings as keys (`html`, `latex`,
+- `lcmark.yaml_parser_name`: a string holding the name of the
+    automatically-loaded module and function used to parse YAML. Possible values
+    are:
+    - `lyaml.load` (lyaml)
+    - `yaml.load` (yaml)
+    - `yaml.eval` (lua-yaml)
+    - `nil` (none) (the value `nil`, not a string)
+
+- `lcmark.writers`: a table with strings as keys (`html`, `latex`,
     `man`, `xml`, `commonmark`) and renderers as values.  A
     renderer is a function that takes three arguments (a
     cmark node, cmark options (a number), and a column width

--- a/bin/lcmark
+++ b/bin/lcmark
@@ -4,14 +4,6 @@
 local optparse = require("optparse")
 local lcmark = require("lcmark")
 
-local lyaml_load do -- Try to load lyaml
-  local success, lyaml = pcall(require, "lyaml")
-  if success then
-    lyaml_load = lyaml.load
-  end
-end
-
-
 local function err(msg, exit_code)
   io.stderr:write("lcmark: " .. msg .. "\n")
   os.exit(exit_code or 1)
@@ -111,7 +103,6 @@ local options = {
   sourcepos = opts.sourcepos,
   columns = opts.columns or 0,
   yaml_metadata = true,
-  yaml_parser = lyaml_load or nil,
   filters = {}
 }
 

--- a/bin/lcmark
+++ b/bin/lcmark
@@ -4,6 +4,14 @@
 local optparse = require("optparse")
 local lcmark = require("lcmark")
 
+local lyaml_load do -- Try to load lyaml
+  local success, lyaml = pcall(require, "lyaml")
+  if success then
+    lyaml_load = lyaml.load
+  end
+end
+
+
 local function err(msg, exit_code)
   io.stderr:write("lcmark: " .. msg .. "\n")
   os.exit(exit_code or 1)
@@ -103,6 +111,7 @@ local options = {
   sourcepos = opts.sourcepos,
   columns = opts.columns or 0,
   yaml_metadata = true,
+  yaml_parser = lyaml_load or nil,
   filters = {}
 }
 

--- a/lcmark.lua
+++ b/lcmark.lua
@@ -23,10 +23,11 @@ local default_yaml_parser = function(...)
   if not yaml then
     local success, loaded = pcall(require, "yaml")
 
-    if success then
+    if success and type(loaded.load) == "function" then
       yaml = loaded
     else
-      error("Failed to load the yaml library. Provide a yaml_parser, or install yaml", 0)
+      error("Failed to load the 'yaml' library. Are you sure you have the " ..
+            "correct library installed and are passing the correct options?", 0)
     end
   end
 

--- a/rockspec.in
+++ b/rockspec.in
@@ -25,7 +25,6 @@ description = {
 dependencies = {
    "lua >= 5.1",
    "cmark >= 0.29.0",
-   "yaml >= 1.1",
    "lpeg >= 0.12",
    "optparse >= 1.0.1",
 }

--- a/test.t
+++ b/test.t
@@ -92,8 +92,26 @@ isnt(body, "Hello \\emph{world}\n", "latex body with yaml_metadata=false")
 eq_array(meta, {}, "latex meta with yaml_metadata=false")
 
 local body, meta, msg = lcmark.convert("---\ntitle: 1: 2\n...\n\nHello *world*", "latex", {yaml_metadata = true})
-is(meta, nil, "latex body nil with bad yaml_metadata")
-like(msg, "YAML parsing error:.*mapping values are not allowed in this context", "error message with bad yaml_metadata")
+is(body, nil, "latex body nil with bad YAML")
+is(meta, nil, "meta nil with bad YAML")
+like(msg, "YAML parsing error:.*mapping values are not allowed in this context", "error message with bad YAML")
+
+local custom_parser = function(s)
+  if s:find("title: 1: 2") then
+    error("bad yaml") -- Simulate error
+  else
+    return {foo = "bar"} -- Simulate success
+  end
+end
+
+local body, meta, msg = lcmark.convert("---\nfoo: bar\n...\n\nHello *world*", "latex", {yaml_metadata = true, yaml_parser = custom_parser})
+is(body, "Hello \\emph{world}\n", "latex body")
+eq_array(meta, {foo = "bar"}, "meta with custom YAML parser")
+
+local body, meta, msg = lcmark.convert("---\ntitle: 1: 2\n...\n\nHello *world*", "latex", {yaml_metadata = true, yaml_parser = custom_parser})
+is(body, nil, "latex body nil with bad YAML and custom YAML parser")
+is(meta, nil, "meta nil with bad YAML and custom YAML parser")
+like(msg, "YAML parsing error:.*bad yaml", "error message with bad YAML and custom YAML parser")
 
 local nonexistent, msg = lcmark.load_filter("nonexistent.lua")
 nok(nonexistent, "load_filter fails on nonexistent filter")

--- a/test.t
+++ b/test.t
@@ -99,6 +99,8 @@ like(msg, "YAML parsing error:.*mapping values are not allowed in this context",
 local custom_parser = function(s)
   if s:find("title: 1: 2") then
     error("bad yaml") -- Simulate error
+  elseif s:find("title: 3: 4") then
+    return nil, "bad yaml" -- Simulate safe error
   else
     return {foo = "bar"} -- Simulate success
   end
@@ -112,6 +114,11 @@ local body, meta, msg = lcmark.convert("---\ntitle: 1: 2\n...\n\nHello *world*",
 nok(body, "latex body nil with bad YAML and custom YAML parser")
 nok(meta, "meta nil with bad YAML and custom YAML parser")
 like(msg, "YAML parsing error:.*bad yaml", "error message with bad YAML and custom YAML parser")
+
+local body, meta, msg = lcmark.convert("---\ntitle: 3: 4\n...\n\nHello *world*", "latex", {yaml_metadata = true, yaml_parser = custom_parser})
+nok(body, "latex body nil with bad YAML and safe custom YAML parser")
+nok(meta, "meta nil with bad YAML and safe custom YAML parser")
+like(msg, "YAML parsing error:.*bad yaml", "error message with bad YAML and safe custom YAML parser")
 
 local nonexistent, msg = lcmark.load_filter("nonexistent.lua")
 nok(nonexistent, "load_filter fails on nonexistent filter")

--- a/test.t
+++ b/test.t
@@ -92,8 +92,8 @@ isnt(body, "Hello \\emph{world}\n", "latex body with yaml_metadata=false")
 eq_array(meta, {}, "latex meta with yaml_metadata=false")
 
 local body, meta, msg = lcmark.convert("---\ntitle: 1: 2\n...\n\nHello *world*", "latex", {yaml_metadata = true})
-is(body, nil, "latex body nil with bad YAML")
-is(meta, nil, "meta nil with bad YAML")
+nok(body, "latex body nil with bad YAML")
+nok(meta, "meta nil with bad YAML")
 like(msg, "YAML parsing error:.*mapping values are not allowed in this context", "error message with bad YAML")
 
 local custom_parser = function(s)
@@ -109,8 +109,8 @@ is(body, "Hello \\emph{world}\n", "latex body")
 eq_array(meta, {foo = "bar"}, "meta with custom YAML parser")
 
 local body, meta, msg = lcmark.convert("---\ntitle: 1: 2\n...\n\nHello *world*", "latex", {yaml_metadata = true, yaml_parser = custom_parser})
-is(body, nil, "latex body nil with bad YAML and custom YAML parser")
-is(meta, nil, "meta nil with bad YAML and custom YAML parser")
+nok(body, "latex body nil with bad YAML and custom YAML parser")
+nok(meta, "meta nil with bad YAML and custom YAML parser")
 like(msg, "YAML parsing error:.*bad yaml", "error message with bad YAML and custom YAML parser")
 
 local nonexistent, msg = lcmark.load_filter("nonexistent.lua")


### PR DESCRIPTION
An alternate implementation of https://github.com/jgm/lcmark/pull/5.

This PR adds a new `yaml_parser` option (a function) that, if provided, will be called instead of `yaml.load`. When not provided, lcmark will try to load the `yaml` library at runtime and use that.

Since `yaml` conflicts with most other Lua YAML libraries (`lyaml`, `lua-yaml`), this PR also removes it from the rockspec dependency list and adds a note to the README.